### PR TITLE
Add support for Apple Silicon M1 macs

### DIFF
--- a/noclamshell
+++ b/noclamshell
@@ -9,4 +9,10 @@ if [ "$LID_CLOSED" ]; then
       pmset sleepnow
     fi
   fi
+
+  NUM_DEVICE_PROXY=$(pmset -g powerstate | grep DCPDPDeviceProxy | wc -l)
+  ARM_AWAKE=$((NUM_DEVICE_PROXY < 4))
+  if [ "$ARM_AWAKE" ]; then
+    pmset sleepnow
+  fi
 fi


### PR DESCRIPTION
the only difference in pmset seems to be the string "DCPDPDeviceProxy"
appearing 3 or 4 times. Tested on my M1 Air (11.2.2) for a few days.